### PR TITLE
Fixed conversion to UTF-8 for parameters passed to FFmpeg

### DIFF
--- a/TVPlayR.Player/ClrStringHelper.h
+++ b/TVPlayR.Player/ClrStringHelper.h
@@ -7,10 +7,9 @@ static std::string ClrStringToStdString(String ^str)
 {
 	if (str == nullptr)
 		return "";
-	IntPtr ansiStr = Runtime::InteropServices::Marshal::StringToHGlobalAnsi(str);
-	std::string outString((const char*)ansiStr.ToPointer());
-	Runtime::InteropServices::Marshal::FreeHGlobal(ansiStr);
-	return outString;
+	array<Byte>^ bytes = System::Text::Encoding::UTF8->GetBytes(str + "\0");
+	pin_ptr<Byte> pinnedBytes = &bytes[0];
+	return reinterpret_cast<char*>(pinnedBytes);
 }
 
 }


### PR DESCRIPTION
Crash when files with names containing non-ANSI characters were parsed.