### PR TITLE
Improved timecode handling

### DIFF
--- a/StudioTVPlayer/ViewModel/MainViewModel.cs
+++ b/StudioTVPlayer/ViewModel/MainViewModel.cs
@@ -42,7 +42,8 @@ namespace StudioTVPlayer.ViewModel
             }
             catch (Exception e)
             {
-                await ShowMessageAsync("Configuration error", $"Configuration data is missing or invalid.\nPlease configure the application to use it.\n\nFollowing error occured:\n{(e.InnerException ?? e).Message}");
+                await ShowMessageAsync("Initialization failed", 
+                    $"Application failed to initialize. It may be configuration problem.\n\nPlease, review the configuration considering following error:\n{(e.InnerException ?? e).Message}");
                 CurrentViewModel = new ConfigurationViewModel();
             }
         }

--- a/TVPlayR.Player/DecklinkOutput.cpp
+++ b/TVPlayR.Player/DecklinkOutput.cpp
@@ -38,7 +38,7 @@ namespace TVPlayR {
 
 	void DecklinkOutput::Initialize(VideoFormat^ format, PixelFormat pixelFormat, int audioChannelsCount, int audioSampleRate)
 	{
-		(*_decklink)->Initialize(format->GetNativeEnumType(), pixelFormat, audioChannelsCount, audioSampleRate);
+		REWRAP_EXCEPTION((*_decklink)->Initialize(format->GetNativeEnumType(), pixelFormat, audioChannelsCount, audioSampleRate);)
 	}
 
 	DecklinkOutput::~DecklinkOutput()

--- a/TVPlayR.Player/TVPlayRException.h
+++ b/TVPlayR.Player/TVPlayRException.h
@@ -6,23 +6,18 @@ namespace TVPlayR {
 	public ref class TVPlayRException : public System::Exception
 	{
 	public:
-		TVPlayRException(Common::TVPlayRException e)
-			: System::Exception(gcnew System::String(e.what()))
-		{
-		}
 		TVPlayRException(std::exception e)
 			: System::Exception(gcnew System::String(e.what())) 
 		{ }
-
+		TVPlayRException(const char* what)
+			: System::Exception(gcnew System::String(what))
+		{
+		}
 	};
 }
 
 #define REWRAP_EXCEPTION(statement)\
  try { statement }\
-  catch (TVPlayR::Common::TVPlayRException te)\
-  {\
-   throw gcnew TVPlayRException(te);\
-  }\
   catch (std::exception e)\
   {\
    throw gcnew TVPlayRException(e);\

--- a/TVPlayRLib/Common/Exceptions.h
+++ b/TVPlayRLib/Common/Exceptions.h
@@ -9,7 +9,7 @@ public:
 	explicit TVPlayRException(char const* const message)
 		: std::exception(message)
 	{ }
-	explicit TVPlayRException(const std::string message)
+	explicit TVPlayRException(const std::string& message)
 		: std::exception(message.c_str())
 	{ }
 };
@@ -17,9 +17,9 @@ public:
 
 #ifdef DEBUG
 #define THROW_EXCEPTION(error_string) {\
-std::string exception_message = std::string(error_string) + std::string(" in ") + std::string(__FUNCTION__) + std::string(" at ") + std::string(__FILE__) + std::string(" in line ") + std::to_string(__LINE__);\
+std::string exception_message = std::string(error_string) + "\nin " + __FUNCTION__ + " at " + __FILE__ + " at line " + std::to_string(__LINE__);\
 OutputDebugStringA((exception_message + "\n").c_str());\
-throw TVPlayR::Common::TVPlayRException(exception_message.c_str()); }
+throw TVPlayR::Common::TVPlayRException(exception_message); }
 #else
 #define THROW_EXCEPTION(error_string) {\
 throw TVPlayR::Common::TVPlayRException(error_string); }

--- a/TVPlayRLib/Decklink/DecklinkInput.cpp
+++ b/TVPlayRLib/Decklink/DecklinkInput.cpp
@@ -160,8 +160,8 @@ namespace TVPlayR {
 			}
 
 			STDMETHODIMP						QueryInterface(REFIID, LPVOID*) override { return E_NOINTERFACE; }
-			virtual ULONG STDMETHODCALLTYPE		AddRef() override { return 1; }
-			virtual ULONG STDMETHODCALLTYPE		Release() override { return 1; }
+			STDMETHODIMP_(ULONG)				AddRef() override { return 1; }
+			STDMETHODIMP_(ULONG)				Release() override { return 1; }
 
 			bool IsAddedToPlayer(const Core::Player& player)
 			{

--- a/TVPlayRLib/Decklink/DecklinkTimecode.cpp
+++ b/TVPlayRLib/Decklink/DecklinkTimecode.cpp
@@ -4,9 +4,8 @@
 
 namespace TVPlayR {
     namespace Decklink {
-        DecklinkTimecode::DecklinkTimecode(Core::VideoFormat& format, std::int64_t time)
-            : ref_count_(0)
-            , time_(time)
+        DecklinkTimecode::DecklinkTimecode(Core::VideoFormat& format)
+            : time_(AV_NOPTS_VALUE)
             , format_(format)
         { }
 
@@ -15,17 +14,17 @@ namespace TVPlayR {
             return time_ != AV_NOPTS_VALUE;
         }
 
+        void DecklinkTimecode::Update(Core::VideoFormat& format, std::int64_t time)
+        {
+            format_ = format;
+            time_ = time;
+        }
+
         STDMETHODIMP DecklinkTimecode::QueryInterface(REFIID, LPVOID*) { return E_NOINTERFACE; }
 
-        STDMETHODIMP_(ULONG) DecklinkTimecode::AddRef() { return InterlockedIncrement(&ref_count_); }
+        STDMETHODIMP_(ULONG) DecklinkTimecode::AddRef() { return 1; }
 
-        STDMETHODIMP_(ULONG) DecklinkTimecode::Release()
-        {
-            ULONG count = InterlockedDecrement(&ref_count_);
-            if (count == 0)
-                delete this;
-            return count;
-        }
+        STDMETHODIMP_(ULONG) DecklinkTimecode::Release() { return 1; }
 
         STDMETHODIMP_(BMDTimecodeBCD) DecklinkTimecode::GetBCD()
         {

--- a/TVPlayRLib/Decklink/DecklinkTimecode.h
+++ b/TVPlayRLib/Decklink/DecklinkTimecode.h
@@ -10,12 +10,12 @@ namespace TVPlayR {
         class DecklinkTimecode final : public IDeckLinkTimecode
         {
         private:
-            ULONG ref_count_;
             std::int64_t time_;
             Core::VideoFormat& format_;
         public:
-            DecklinkTimecode(Core::VideoFormat& format, std::int64_t time);
+            DecklinkTimecode(Core::VideoFormat& format);
             bool IsValid() const;
+            void Update(Core::VideoFormat& format, std::int64_t time);
             //IUnknown
             STDMETHOD(QueryInterface(REFIID, LPVOID*));
             STDMETHOD_(ULONG, AddRef());

--- a/TVPlayRLib/Decklink/DecklinkVideoFrame.h
+++ b/TVPlayRLib/Decklink/DecklinkVideoFrame.h
@@ -16,9 +16,9 @@ namespace TVPlayR {
 			int width_, height_;
 			int row_bytes_;
 			BMDPixelFormat pixel_format_;
-			std::shared_ptr<DecklinkTimecode> timecode_;
+			DecklinkTimecode timecode_;
 		public:
-			DecklinkVideoFrame();
+			DecklinkVideoFrame(Core::VideoFormat& format);
 			virtual ~DecklinkVideoFrame();
 
 			void Update(Core::VideoFormat& format, const std::shared_ptr<AVFrame>& frame, std::int64_t timecode);


### PR DESCRIPTION
Improved timecode handling that used to cause not reproduced weird behavior. Also improved decklink initialization handling.
Simplified ownership of DecklinkTimecode - now it's part of DecklinkVideoFrame.