### PR TITLE
Fixed Windows7 support

### DIFF
--- a/TVPlayRLib/Common/Executor.h
+++ b/TVPlayRLib/Common/Executor.h
@@ -3,6 +3,7 @@
 namespace TVPlayR {
     namespace Common {
 
+#ifdef DEBUG
         static void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
         {
             HANDLE hThread = ::GetCurrentThread();
@@ -15,8 +16,9 @@ namespace TVPlayR {
                     ::SetThreadDescription(hThread, wThreadName);
             }
             catch (...) {}
-            delete wThreadName;
+            delete[] wThreadName;
         }
+#endif
 
     class Executor final
     {
@@ -100,7 +102,9 @@ namespace TVPlayR {
     private:
         void run(std::string name)
         {
+#ifdef DEBUG
             SetThreadName(::GetCurrentThreadId(), name.c_str());
+#endif
             std::function<void()> task;
             while (is_running_) {
                 try {

--- a/TVPlayRLib/FFmpeg/FFmpegInput.cpp
+++ b/TVPlayRLib/FFmpeg/FFmpegInput.cpp
@@ -60,7 +60,9 @@ struct FFmpegInput::implementation : Common::DebugTarget, FFmpegInputBase
 
 	void ProducerTheradStart()
 	{
+#ifdef DEBUG
 		Common::SetThreadName(::GetCurrentThreadId(), ("FFmpegInput " + file_name_).c_str());
+#endif
 		is_producer_running_ = true;
 		std::unique_lock<std::mutex> wait_lock(producer_mutex_);
 		producer_cv_.wait(wait_lock, [&]()


### PR DESCRIPTION
 SetThreadDescription() now called only in debug builds as it's unavailable in Windows 7 kernel, and only useful during development.